### PR TITLE
Updated pull request template to include approver checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,14 @@ _Add steps for how these changes can be viewed or tested_
 - [ ] Title begins with ClickUp custom id and title of work item ex. `RD-123 ClickUp Work Item Title`
 - [ ] Label matches the ClickUp work item type
 
+## :checkered_flag: Approver Checklist
+_This list can be updated in the PR description itself or added to the review comment_
+- [ ] Title begins with ClickUp custom id and title of work item
+- [ ] Label matches the ClickUp work item type
+- [ ] Changes are scoped to one work item
+- [ ] Description of Changes adequately describes the changes
+- [ ] Changes have been documented as described
+- [ ] These changes have been viewed/tested according to the description
 
 <!-- 
 JUST FOR REFERNCE WILL NOT SHOW IN PR BUT CAN BE REMOVED


### PR DESCRIPTION
## :pencil: Description of Changes
Updated the pull request template to add an approvers checklist.


## :books: Where are these changes documented?
This change is a non-production change and therefore this change does not need to be documented.


## :eyes: How can these changes be viewed/tested?
This change will be present when a pull request is created.


## :ballot_box_with_check: Pull Request Checklist
- [ ] Title begins with ClickUp custom id and title of work item ex. `RD-123 ClickUp Work Item Title`
- [ ] Label matches the ClickUp work item type

## :checkered_flag: Approver Checklist
_This list can be updated in the PR description itself or added to the review comment_
- [ ] Title begins with ClickUp custom id and title of work item
- [ ] Label matches the ClickUp work item type
- [ ] Changes are scoped to one work item
- [ ] Description of Changes adequately describes the changes
- [ ] Changes have been documented as described
- [ ] These changes have been viewed/tested according to the description

<!-- 
JUST FOR REFERNCE WILL NOT SHOW IN PR BUT CAN BE REMOVED
For ClickUp Work Items use this format: Fixes RD-123
https://docs.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops

For GitHub Issues use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

For Grand Avenue Documents add a link to the document using the following format: [Document Name](Link to the document)
-->

